### PR TITLE
Add support for nav_msgs::Odometry as initial guess

### DIFF
--- a/include/icp_cpp/conversion.h
+++ b/include/icp_cpp/conversion.h
@@ -6,6 +6,7 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/LaserScan.h>
 #include <std_msgs/Float64MultiArray.h>
+#include <nav_msgs/Odometry.h>
 
 // Third Party
 #include <Eigen/Dense>
@@ -47,6 +48,12 @@ Eigen::MatrixXd PointCloud2ToMatrix(const sensor_msgs::PointCloud2ConstPtr& inpu
 */
 Eigen::MatrixXd MultiArrayToMatrix(const std_msgs::Float64MultiArray& matrix);
 
+/*
+* @brief turns a nav_msgs::Odometry into an Eigen::MatrixXd of size(4, 4) representing a transformation matrix
+* @param odometry odometry message
+*/
+Eigen::MatrixXd OdometryToMatrix(const nav_msgs::Odometry& odom);
+
 /*----------------------Output Conversions------------------------*/
 
 /*
@@ -61,6 +68,12 @@ sensor_msgs::PointCloud2 MatrixToPointCloud2(const Eigen::MatrixXd& pc_matrix, s
 * @brief turns an Eigen::MatrixXd into a Float64MultiArray of matching dimensions.
 * @param matrix dynamic size matrix of doubles
 */
-std_msgs::Float64MultiArray MatrixToMultiArray(const Eigen::MatrixXd& matrix);
+std_msgs::Float64MultiArray MatrixToMultiArray(const Eigen::Matrix4d& matrix);
+
+/*
+* @brief turns a nav_msgs::Odometry into an Eigen::Matrix4d representing a transformation matrix
+* @param odometry odometry message
+*/
+nav_msgs::Odometry MatrixToOdometry(const Eigen::Matrix4d& matrix);
 
 #endif //ICP_CONVERSION_H

--- a/include/icp_cpp/program_options.h
+++ b/include/icp_cpp/program_options.h
@@ -10,20 +10,36 @@
 constexpr int kMaxNumDefaultIterations = 100;
 
 struct ProgramOptions {
+  // Mode
   std::string mode{"sequential"};
+  int max_num_iterations = kMaxNumDefaultIterations;
+
+  // Input Scan Topics
   std::string input_scan_a_topic{"scan"};
-  std::string initial_guess_topic{"transform_matrix"};
   std::string input_scan_b_topic{"scan_b"};
+
+  // Input Scan Types
   std::string input_scan_a_type{"laserscan"};
   std::string input_scan_b_type{"laserscan"};
-  std::string output_transform_matrix_topic{"transform_matrix"};
-  int max_num_iterations = kMaxNumDefaultIterations;
+
+  // Initial Guess
+  std::string initial_guess_topic{"odom"};
+  std::string initial_guess_type{"odometry"};
+
+  // Output Transform
+  std::string output_transform_topic{"transform"};
   std::string frame_id{"laser"};
+
+  // Debug Stepwise mode options
   float stepwise_time_interval{0.01};
   bool show_each_step{false};
+
+  // Debug Working Scan Publishers
   bool pub_scan_a{false};
   bool pub_trans_scan_a{false};
   bool pub_scan_b{false};
+
+  // Output topics
   std::string output_scan_a_topic{"scan_a_out"};
   std::string output_stepwise_a_topic{"scan_a_stepwise"};
   std::string output_trans_scan_a_topic{"scan_a_transformed_out"};
@@ -38,16 +54,18 @@ ProgramOptions ParseArgs(int argc, char** argv) {
     cxxopts::value<std::string>(program_options.mode)->default_value("sequential"))
     ("a,in_a", "input topic to receive scan A on",
     cxxopts::value<std::string>(program_options.input_scan_a_topic)->default_value("scan"))
-    ("g,init_guess", "input topic to receive initial guess on",
-    cxxopts::value<std::string>(program_options.initial_guess_topic)->default_value("transform_matrix"))
     ("b,in_b", "input topic to receive scan B on",
     cxxopts::value<std::string>(program_options.input_scan_b_topic)->default_value("scan_b"))
+    ("g,init_guess", "topic to receive initial guess transform on",
+    cxxopts::value<std::string>(program_options.initial_guess_topic)->default_value("odom"))
+    ("in_transform_type", "message type of initial guess ['multiarray', 'odometry']",
+    cxxopts::value<std::string>(program_options.initial_guess_type)->default_value("odometry"))
     ("a_type", "message type of scan A, ['laserscan' 'pointcloud' or 'pointcloud2']",
     cxxopts::value<std::string>(program_options.input_scan_a_type)->default_value("laserscan"))
     ("b_type", "message type of scan B, ['laserscan' 'pointcloud' or 'pointcloud2']",
     cxxopts::value<std::string>(program_options.input_scan_b_type)->default_value("laserscan"))
-    ("transform_topic", "topic to publish transformation matrix on",
-    cxxopts::value<std::string>(program_options.output_transform_matrix_topic)->default_value("transform_matrix"))
+    ("transform_topic", "topic to publish transform on",
+    cxxopts::value<std::string>(program_options.output_transform_topic)->default_value("transform"))
     ("i,max_num_iterations", "max scan matcher iterations before exiting",
     cxxopts::value<int>(program_options.max_num_iterations)->default_value(std::to_string(kMaxNumDefaultIterations)))
     ("f,frame_id", "tf frame id",

--- a/include/icp_cpp/scanmatcher_driver.h
+++ b/include/icp_cpp/scanmatcher_driver.h
@@ -15,6 +15,7 @@
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_msgs/Float64MultiArray.h>
+#include <nav_msgs/Odometry.h>
 #include <ros/ros.h>
 
 // Third Party
@@ -80,11 +81,21 @@ private:
   void PC2Callback(const sensor_msgs::PointCloud2ConstPtr& input_cloud, const std::string &topic);
 
   /*
-  * @brief Initial Guess matrix callback.
+  * @brief Initial Guess Float64MultiArray callback.
   * Sets ICP initial guess to the matrix received on the initial_guess_topic.
   * @param initial_guess 4D transformation matrix encoding initial transform for Scan A
   */
-  void InitialGuessCallback(const std_msgs::Float64MultiArray& initial_guess);
+  void InitialGuessMatrixCallback(const std_msgs::Float64MultiArray& initial_guess);
+
+  /*
+  * @brief Initial Guess nav_msgs::Odometry callback.
+  * If this is the first odom message, sets a reference inverse pose matrix
+  * which all subsequent odom matrices are transformed with respect to
+  * in order to obtain an initial guess transform.
+  * Sets ICP initial guess to the odometry message received on the initial_guess_topic.
+  * @param initial_guess odometry message with initial guess transform info for scan A
+  */
+  void InitialGuessOdometryCallback(const nav_msgs::Odometry& initial_guess);
 
   /*
   * @brief Process an input scan received on the scan_a input topic.
@@ -148,6 +159,8 @@ private:
   std::string input_a_topic_;                                       // Topic to receive Scan A on (used in sequential and A-to-B mode)
   std::string input_b_topic_;                                       // Topic to receive Scan B on (A-to-B mode only)
   bool show_each_step_;                                             // Flag to run ICP in show_each_step mode
+  Eigen::Matrix4d init_pose_{Eigen::Matrix4d::Zero()};              // 4D transformation matrix representing initial odom pose
+  bool has_init_pose_{false};
   std::unique_ptr<ros::Duration> stepwise_time_interval_;           // Pointer to ros::Duration time interval to wait in between iterations (in stepwise scan mode)
   std::unique_ptr<ros::Publisher> transform_publisher_{nullptr};    // Pointer to transformation matrix publisher
   std::unique_ptr<ros::Publisher> scan_a_publisher_{nullptr};       // Pointer to scan a publisher
@@ -156,7 +169,7 @@ private:
   std::unique_ptr<ros::Publisher> scan_b_publisher_{nullptr};       // Pointer to scan b publisher
   std::unique_ptr<ros::Subscriber> scan_a_subscriber_{nullptr};     // Pointer to scan a subscriber
   std::unique_ptr<ros::Subscriber> scan_b_subscriber_{nullptr};     // Pointer to scan b subscriber
-  std::unique_ptr<ros::Subscriber> guess_subscriber_{nullptr};     // Pointer to initial guess subscriber
+  std::unique_ptr<ros::Subscriber> guess_subscriber_{nullptr};      // Pointer to initial guess subscriber
 };
 
 #endif //ICP_DRIVER_H

--- a/src/conversion.cpp
+++ b/src/conversion.cpp
@@ -6,9 +6,12 @@
 #include <sensor_msgs/LaserScan.h>
 #include <std_msgs/Float64MultiArray.h>
 #include <laser_geometry/laser_geometry.h>
+#include <nav_msgs/Odometry.h>
+#include <geometry_msgs/PoseWithCovariance.h>
 
 // Third Party
 #include <Eigen/Dense>
+#include <Eigen/Geometry>
 
 // ICP
 #include "icp_cpp/conversion.h"
@@ -72,7 +75,7 @@ sensor_msgs::PointCloud2 MatrixToPointCloud2(const Eigen::MatrixXd& pc_matrix, s
   return cloud_msg;
 }
 
-std_msgs::Float64MultiArray MatrixToMultiArray(const Eigen::MatrixXd& matrix) {
+std_msgs::Float64MultiArray MatrixToMultiArray(const Eigen::Matrix4d& matrix) {
   std_msgs::Float64MultiArray out;
 
   int rows = matrix.rows();
@@ -112,5 +115,22 @@ Eigen::MatrixXd MultiArrayToMatrix(const std_msgs::Float64MultiArray& matrix) {
     }
   }
 
+  return out;
+}
+
+Eigen::MatrixXd OdometryToMatrix(const nav_msgs::Odometry& odom) {
+  Eigen::MatrixXd out = Eigen::MatrixXd::Zero(4, 4);
+  double x = odom.pose.pose.position.x;
+  double y = odom.pose.pose.position.y;
+  double z = odom.pose.pose.position.z;
+
+  double qx = odom.pose.pose.orientation.x;
+  double qy = odom.pose.pose.orientation.y;
+  double qz = odom.pose.pose.orientation.z;
+  double qw = odom.pose.pose.orientation.w;
+  Eigen::Quaterniond q (qw, qx, qy, qz);
+
+  out.block<3,1>(0,3) << x, y, z;
+  out.block<3,3>(0,0) = q.toRotationMatrix();
   return out;
 }


### PR DESCRIPTION
By default, the scan matcher accepts a nav_msgs::Odometry as input and computes the relative transform between the first odom pose it received and the current one. 